### PR TITLE
Export interfaces separately

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9036,9 +9036,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.14.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.1.tgz",
-      "integrity": "sha512-+ahUAE+iheqBTDxXhTisdA8hgvbEG1hHOQ9xmNjeUJSoi6DU/gMrKNcfZjHkyY6Alnuyc+ikYJaxxfHkT3+WuQ==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
@@ -17079,9 +17079,9 @@
       }
     },
     "terser": {
-      "version": "5.14.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.1.tgz",
-      "integrity": "sha512-+ahUAE+iheqBTDxXhTisdA8hgvbEG1hHOQ9xmNjeUJSoi6DU/gMrKNcfZjHkyY6Alnuyc+ikYJaxxfHkT3+WuQ==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
       "dev": true,
       "requires": {
         "@jridgewell/source-map": "^0.3.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,21 +15,25 @@ const log = Debug("xummpkce");
 
 log("Xumm OAuth2 PKCE Authorization Code Flow lib.");
 
-interface ResolvedFlow {
+export { XummSdkJwt };
+
+export interface Me {
+  sub: string;
+  picture: string;
+  account: string;
+  name?: string;
+  domain?: string;
+  blocked: boolean;
+  source: string;
+  kycApproved: boolean;
+  proSubscription: boolean;
+};
+
+export interface ResolvedFlow {
   sdk: XummSdkJwt;
   jwt: string;
-  me: {
-    sub: string;
-    picture: string;
-    account: string;
-    name?: string;
-    domain?: string;
-    blocked: boolean;
-    source: string;
-    kycApproved: boolean;
-    proSubscription: boolean;
-  };
-}
+  me: Me;
+};
 
 export interface XummPkceEvent {
   // Result returns nothing, just a trigger, the authorize() method should be called later to handle based on Promise()


### PR DESCRIPTION
This PR exports some existing interfaces separately so we can import them into our project. That way we can take the data returned from `authorize()` and store them in our state with the proper types.

Also ran `npm audit fix` which updated the `terser` dependency since it contained a vulnerability.