### PR TITLE
fix XummPkceOptions field optional

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ export class XummPkceThread extends EventEmitter {
 
   constructor(
     xummApiKey: string,
-    optionsOrRedirectUrl?: string | XummPkceOptions
+    optionsOrRedirectUrl?: string | Partial<XummPkceOptions>
   ) {
     super();
 


### PR DESCRIPTION
When setting options, they are originally optional items, but now all fields must be set.