### PR TITLE
`XummPkce.state()` value is not updated at logout.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -440,6 +440,7 @@ export class XummPkceThread extends EventEmitter {
       this.autoResolvedFlow = undefined;
       this.options.storage?.removeItem("XummPkceJwt");
       this.mobileRedirectFlow = false;
+      this.promise = undefined
     } catch (e) {
       // Nothing to do
     }


### PR DESCRIPTION
When XummPkce.state() was read after logout, 
it should return undefined, but the value (ResolvedFlow) before logout was returned.