### PR TITLE
fix: update me of ResolvedFlow

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,13 +45,17 @@ export interface ResolvedFlow {
     sub: string;
     picture: string;
     account: string;
-    name?: string;
-    domain?: string;
+    name?: string | null;
+    domain?: string | null;
     blocked: boolean;
     source: string;
     kycApproved: boolean;
     proSubscription: boolean;
     profile?: XummProfile;
+    networkType?: string;
+    networkId?: number;
+    networkEndpoint?: string;
+    email?: string;
   };
 }
 


### PR DESCRIPTION
There are inconsistencies between type definitions and actual response data from `ResolvedFlow.me`:

1. `name` and `domain` fields can be `null` (not just `undefined`). I added `| null` while keeping optional chaining for backward compatibility.

3. There are some missing fields from the API response:

```
networkType?: string;
networkId?: number;
networkEndpoint?: string;
email?: string;
```
 
I couldn't find documentation for the `https://oauth2.xumm.app/userinfo` endpoint, so I'm not sure if these fields are nullable. Would appreciate if you could check this.